### PR TITLE
Failed to activate store apps

### DIFF
--- a/src/WinAppDriver/IUtils.cs
+++ b/src/WinAppDriver/IUtils.cs
@@ -117,9 +117,9 @@
                     // Seems like a timing issue that the built-in Directory.Delete(path, true)
                     // did not take into account.
                     logger.Warn("IOException raised while deleting the directory: {0} ({1})", path, e.Message);
-                    logger.Debug("Sleep for a while (2s), and try again...");
+                    logger.Debug("Sleep for a while (5s), and try again...");
 
-                    System.Threading.Thread.Sleep(2000);
+                    System.Threading.Thread.Sleep(5000);
                     Directory.Delete(path);
                 }
 

--- a/src/WinAppDriver/Modern/StoreApp.cs
+++ b/src/WinAppDriver/Modern/StoreApp.cs
@@ -127,7 +127,7 @@
 
             var process = Process.Start(info);
             logger.Debug("PID of ActivateStoreApp.exe = {0}.", process.Id);
-            process.WaitForExit(5 * 1000);
+            process.WaitForExit();
 
             if (process.ExitCode == 0)
             {

--- a/src/WinAppDriver/Modern/StoreApp.cs
+++ b/src/WinAppDriver/Modern/StoreApp.cs
@@ -113,8 +113,36 @@
 
         public void Activate()
         {
-            // TODO thorw exception if needed
-            Process.Start("ActivateStoreApp", this.AppUserModelId);
+            logger.Info(
+                "Activate the store app; current working directory = [{0}], " +
+                "AppUserModelID = [{1}].",
+                Environment.CurrentDirectory, this.AppUserModelId);
+
+            var info = new ProcessStartInfo(
+                Path.Combine(Environment.CurrentDirectory, "ActivateStoreApp.exe"),
+                this.AppUserModelId);
+            info.UseShellExecute = false;
+            info.RedirectStandardOutput = true;
+            info.RedirectStandardError = true;
+
+            var process = Process.Start(info);
+            logger.Debug("PID of ActivateStoreApp.exe = {0}.", process.Id);
+            process.WaitForExit(5 * 1000);
+
+            if (process.ExitCode == 0)
+            {
+                logger.Debug("STDOUT = [{0}].", process.StandardOutput.ReadToEnd());
+            }
+            else
+            {
+                string msg = string.Format(
+                    "Error occurred while activating the store app; " +
+                    "code = {0}, STDOUT = [{1}], STDERR = [{2}].",
+                    process.ExitCode,
+                    process.StandardOutput.ReadToEnd(),
+                    process.StandardError.ReadToEnd());
+                throw new WinAppDriverException(msg);
+            }
         }
 
         public void Terminate()


### PR DESCRIPTION
More than one users report that store apps cannot be activated successfully (#12, #17 and #21).

```
[Error] WinAppDriver: Error occurred.
System.ComponentModel.Win32Exception (0x80004005): The system cannot find the file specified.
...
    at WinAppDriver.Modern.StoreApp.Activate() in ...
```